### PR TITLE
Add new queue to bulk-scan NS but for reform only

### DIFF
--- a/queue.tf
+++ b/queue.tf
@@ -1,0 +1,30 @@
+module "queue-namespace" {
+  source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
+  name                = "${local.bsp_product}-servicebus-${var.env}"
+  location            = "${var.location}"
+  resource_group_name = "${azurerm_resource_group.bulkscan_rg.name}"
+  env                 = "${var.env}"
+  common_tags         = "${var.common_tags}"
+}
+
+module "notifications-queue" {
+  source              = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
+  name                = "notifications-reform"
+  namespace_name      = "${module.queue-namespace.name}"
+  resource_group_name = "${azurerm_resource_group.bulkscan_rg.name}"
+  lock_duration       = "PT5M"
+
+  duplicate_detection_history_time_window = "PT15M"
+}
+
+resource "azurerm_key_vault_secret" "notifications_queue_send_conn_str" {
+  key_vault_id = "${data.azurerm_key_vault.key_vault.id}"
+  name         = "notifications-queue-send-connection-string"
+  value        = "${module.notifications-queue.primary_send_connection_string}"
+}
+
+resource "azurerm_key_vault_secret" "notifications_queue_listen_conn_str" {
+  key_vault_id = "${data.azurerm_key_vault.key_vault.id}"
+  name         = "notifications-queue-listen-connection-string"
+  value        = "${module.notifications-queue.primary_listen_connection_string}"
+}

--- a/resource-group.tf
+++ b/resource-group.tf
@@ -1,9 +1,17 @@
 locals {
-  tags = "${merge(var.common_tags, map("Team Contact", "#rbs"))}"
+  bsp_product = "bulk-scan"
+  tags        = "${merge(var.common_tags, map("Team Contact", "#rbs"))}"
 }
 
 resource "azurerm_resource_group" "rg" {
   name     = "${var.product}-${var.env}"
+  location = "${var.location}"
+
+  tags = "${local.tags}"
+}
+
+resource "azurerm_resource_group" "bulkscan_rg" {
+  name     = "${local.bsp_product}-${var.env}"
   location = "${var.location}"
 
   tags = "${local.tags}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Create notification queue for reform blob router](https://tools.hmcts.net/jira/browse/BPS-975)

### Change description ###

Create new queue for notifications originating from reform scan components. Re-using existing bulk scan namespace/queue as information passed around using that queue will not provide any significant information which will be of a concern to other third parties

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
