### PR TITLE
Break the pipeline for prod

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,6 +6,10 @@ def product = 'reform-scan'
 
 withInfraPipeline(product) {
 
+  before('buildinfra:prod') {
+    error 'Deliberately breaking pipeline to prevent prod deployment - checking critical changes in aat first'
+  }
+
   enableSlackNotifications('#bsp-build-notices')
 
 }


### PR DESCRIPTION
### Change description ###

Break the pipeline for prod, so that infra changes (including tf state deletion) can be safely verified in aat first.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
