### PR TITLE
Use the branch of palo-alto module that has pip upgraded

### DIFF
--- a/palo-alto.tf
+++ b/palo-alto.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "palo_alto" {
-  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=master"
+  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"
   subscription = "${var.subscription}"
   env          = "${var.env}"
   product      = "${var.product}"


### PR DESCRIPTION
### Change description ###

Use the branch of palo-alto module that has pip upgraded (by analogy to https://github.com/hmcts/bulk-scan-shared-infrastructure/pull/160). Without this change, terraform apply fails in the pipeline.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
