### PR TITLE
Updated certs for aat and demo as old ones expired

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,3 +1,3 @@
-external_cert_name = "star-aat"
+external_cert_name = "wildcard-aat-platform-hmcts-net"
 
 managed_identity_object_id = "85e00c71-7aae-4c14-86e2-7589f60b3357"

--- a/app-gateway.tf
+++ b/app-gateway.tf
@@ -8,6 +8,11 @@ data "azurerm_key_vault_secret" "cert" {
   name         = "${var.external_cert_name}"
 }
 
+data "azurerm_key_vault_secret" "cert_password" {
+  name      = "${var.external_cert_name}-password"
+  key_vault_id = "${data.azurerm_key_vault.infra_vault.id}"
+}
+
 module "appGw" {
   source            = "git@github.com:hmcts/cnp-module-waf?ref=master"
   env               = "${var.env}"
@@ -29,7 +34,7 @@ module "appGw" {
     {
       name     = "${var.external_cert_name}"
       data     = "${data.azurerm_key_vault_secret.cert.value}"
-      password = ""
+      password = "${var.env == "prod" ? "" : "${data.azurerm_key_vault_secret.cert_password.value}"}"
     },
   ]
 

--- a/demo.tfvars
+++ b/demo.tfvars
@@ -1,3 +1,3 @@
-external_cert_name = "star-demo"
+external_cert_name = "wildcard-aat-platform-hmcts-net"
 
 managed_identity_object_id = "7ccfea9c-730f-4aa2-995b-248dffd4f7e7"


### PR DESCRIPTION
### Change description ###

- `star-aat` and `star-demo` certs expired on 24/04/2020. Hence Devops has got new cert now.

- Cert for non prod would be same and also needs a password now.

- Password is being set as a secret in vault.

- Prod cert is not expired hence no change to that.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
