### PR TITLE
Refer to branch of palo module containing pdf threat exclusion

### DIFF
--- a/palo-alto-staging.tf
+++ b/palo-alto-staging.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "palo_alto_staging" {
-  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"
+  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=add-pdf-threat-exclusion"
   subscription = "${var.subscription}"
   env          = "${var.env}"
   product      = "${var.product}-stg"

--- a/palo-alto.tf
+++ b/palo-alto.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "palo_alto" {
-  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"
+  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=add-pdf-threat-exclusion"
   subscription = "${var.subscription}"
   env          = "${var.env}"
   product      = "${var.product}"


### PR DESCRIPTION
* Previous pip upgrade branch changes have been merged to master now 
* `add-pdf-threat-exclusion` includes adding exclusion for PDF threat id 34805 https://github.com/hmcts/cnp-module-palo-alto/tree/add-pdf-threat-exclusion
More details are included here https://tools.hmcts.net/jira/browse/BPS-1117
* This exclusion is currently applied by Devops manually on palo instances so it is currently in prod and being approved by IA.
* We can't merge the exclusion change to master as it will apply to all the consumers of palo module.
* Also soon we are migrating to shared Palos so this should be just an interim solution.
