### PR TITLE
Add shared access key to vault for notification queues

### DIFF
--- a/queue.tf
+++ b/queue.tf
@@ -29,6 +29,18 @@ resource "azurerm_key_vault_secret" "notifications_queue_listen_conn_str" {
   value        = "${module.notifications-queue.primary_listen_connection_string}"
 }
 
+resource "azurerm_key_vault_secret" "notification_queue_send_access_key" {
+  name      = "notification-queue-send-shared-access-key"
+  value     = "${module.notifications-queue.primary_send_shared_access_key}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "notification_queue_listen_access_key" {
+  name      = "notification-queue-listen-shared-access-key"
+  value     = "${module.notifications-queue.primary_listen_shared_access_key}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
 module "notifications-staging-queue" {
   source              = "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"
   name                = "notifications-staging"
@@ -49,4 +61,16 @@ resource "azurerm_key_vault_secret" "notifications_staging_queue_listen_conn_str
   key_vault_id = "${data.azurerm_key_vault.key_vault.id}"
   name         = "notifications-staging-queue-listen-connection-string"
   value        = "${module.notifications-staging-queue.primary_listen_connection_string}"
+}
+
+resource "azurerm_key_vault_secret" "notification_staging_queue_send_access_key" {
+  name      = "notification-staging-queue-send-shared-access-key"
+  value     = "${module.notifications-staging-queue.primary_send_shared_access_key}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "notification_staging_queue_listen_access_key" {
+  name      = "notification-staging-queue-listen-shared-access-key"
+  value     = "${module.notifications-staging-queue.primary_listen_shared_access_key}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Improve the way Service Bus clients are created](https://tools.hmcts.net/jira/browse/BPS-771)

### Change description ###

While browsing bulk scan processor repo noticed secret is copied from here as it is also pushing error notifications from there.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
