### PR TITLE
Added security rule for service tag to allow azure storage traffic through the NSG

### DIFF
--- a/app-gateway-nsg.tf
+++ b/app-gateway-nsg.tf
@@ -75,7 +75,7 @@ resource "azurerm_network_security_group" "reformscannsg" {
     direction                  = "Inbound"
     access                     = "Allow"
     priority                   = 130
-    source_address_prefix    = "Storage"
+    source_address_prefix      = "Storage"
     source_port_range          = "*"
     destination_address_prefix = "*"
     destination_port_range     = "443"

--- a/app-gateway-nsg.tf
+++ b/app-gateway-nsg.tf
@@ -69,6 +69,18 @@ resource "azurerm_network_security_group" "reformscannsg" {
     destination_port_range     = "443"
     protocol                   = "TCP"
   }
+  
+  security_rule {
+    name                       = "AllowAzureStorageInBound"
+    direction                  = "Inbound"
+    access                     = "Allow"
+    priority                   = 130
+    source_address_prefixes    = "Storage"
+    source_port_range          = "*"
+    destination_address_prefix = "*"
+    destination_port_range     = "443"
+    protocol                   = "*"
+  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "subnet_nsg_association" {

--- a/app-gateway-nsg.tf
+++ b/app-gateway-nsg.tf
@@ -75,7 +75,7 @@ resource "azurerm_network_security_group" "reformscannsg" {
     direction                  = "Inbound"
     access                     = "Allow"
     priority                   = 130
-    source_address_prefixes    = "Storage"
+    source_address_prefix    = "Storage"
     source_port_range          = "*"
     destination_address_prefix = "*"
     destination_port_range     = "443"


### PR DESCRIPTION

### Change description ###

- This change is currently manually applied to AAT as otherwise it blocks functional tests to access the blob storage to upload files.

- This change should only be merged during window agreed with scanning supplier to avoid them getting blocked to upload zip files on prod.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
