### PR TITLE
Update keyvault config to support multiple managed identities

### DIFF
--- a/vault.tf
+++ b/vault.tf
@@ -10,7 +10,7 @@ module "vault" {
   common_tags             = "${local.tags}"
   location                = "${var.location}"
 
-  managed_identity_object_id = "${var.managed_identity_object_id}"
+  managed_identity_object_ids = ["${var.managed_identity_object_id}"]
 }
 
 data "azurerm_key_vault" "key_vault" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1366


### Change description ###
core-api-management needs to have access to keyvault to read the reconciliation api key secret.
This PR just changes the key vault config to accept multiple values of managed identities.
After testing the change in demo, I'll add the core api management identity. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes 
[x] No 
```
