### PR TITLE
add subnets required for smoketest and shared infra

### DIFF
--- a/blob-storage-staging.tf
+++ b/blob-storage-staging.tf
@@ -25,6 +25,20 @@ data "azurerm_subnet" "jenkins_subnet_stg" {
   resource_group_name  = "${local.mgmt_network_rg_name_stg}"
 }
 
+data "azurerm_subnet" "aks_00_subnet_stg" {
+  provider             = "azurerm.mgmt"
+  name                 = "aks-00"
+  virtual_network_name = "${local.mgmt_network_name_stg}"
+  resource_group_name  = "${local.mgmt_network_rg_name_stg}"
+}
+
+data "azurerm_subnet" "aks_01_subnet_stg" {
+  provider             = "azurerm.mgmt"
+  name                 = "aks-01"
+  virtual_network_name = "${local.mgmt_network_name_stg}"
+  resource_group_name  = "${local.mgmt_network_rg_name_stg}"
+}
+
 resource "azurerm_storage_account" "storage_account_staging" {
   name                = "${local.account_name_stg}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
@@ -40,7 +54,7 @@ resource "azurerm_storage_account" "storage_account_staging" {
   }
 
   network_rules {
-    virtual_network_subnet_ids = ["${data.azurerm_subnet.trusted_subnet_stg.id}", "${data.azurerm_subnet.jenkins_subnet_stg.id}"]
+    virtual_network_subnet_ids = ["${data.azurerm_subnet.trusted_subnet_stg.id}", "${data.azurerm_subnet.jenkins_subnet_stg.id}", "${data.azurerm_subnet.aks_00_subnet_stg.id}", "${data.azurerm_subnet.aks_01_subnet_stg.id}"]
     bypass                     = ["Logging", "Metrics", "AzureServices"]
     default_action             = "Deny"
   }

--- a/blob-storage.tf
+++ b/blob-storage.tf
@@ -31,14 +31,14 @@ data "azurerm_subnet" "jenkins_subnet" {
   resource_group_name  = "${local.mgmt_network_rg_name}"
 }
 
-data "azurerm_subnet" "aks_00_subnet_stg" {
+data "azurerm_subnet" "aks_00_subnet" {
   provider             = "azurerm.mgmt"
   name                 = "aks-00"
   virtual_network_name = "${local.mgmt_network_name_stg}"
   resource_group_name  = "${local.mgmt_network_rg_name_stg}"
 }
 
-data "azurerm_subnet" "aks_01_subnet_stg" {
+data "azurerm_subnet" "aks_01_subnet" {
   provider             = "azurerm.mgmt"
   name                 = "aks-01"
   virtual_network_name = "${local.mgmt_network_name_stg}"
@@ -60,7 +60,7 @@ resource "azurerm_storage_account" "storage_account" {
   }
 
   network_rules {
-    virtual_network_subnet_ids = ["${data.azurerm_subnet.trusted_subnet.id}", "${data.azurerm_subnet.jenkins_subnet.id}", "${data.azurerm_subnet.aks_00_subnet_stg.id}", "${data.azurerm_subnet.aks_01_subnet_stg.id}"]
+    virtual_network_subnet_ids = ["${data.azurerm_subnet.trusted_subnet.id}", "${data.azurerm_subnet.jenkins_subnet.id}", "${data.azurerm_subnet.aks_00_subnet.id}", "${data.azurerm_subnet.aks_01_subnet.id}"]
     bypass                     = ["Logging", "Metrics", "AzureServices"]
     default_action             = "Deny"
   }

--- a/blob-storage.tf
+++ b/blob-storage.tf
@@ -34,15 +34,15 @@ data "azurerm_subnet" "jenkins_subnet" {
 data "azurerm_subnet" "aks_00_subnet" {
   provider             = "azurerm.mgmt"
   name                 = "aks-00"
-  virtual_network_name = "${local.mgmt_network_name_stg}"
-  resource_group_name  = "${local.mgmt_network_rg_name_stg}"
+  virtual_network_name = "${local.mgmt_network_name}"
+  resource_group_name  = "${local.mgmt_network_rg_name}"
 }
 
 data "azurerm_subnet" "aks_01_subnet" {
   provider             = "azurerm.mgmt"
   name                 = "aks-01"
-  virtual_network_name = "${local.mgmt_network_name_stg}"
-  resource_group_name  = "${local.mgmt_network_rg_name_stg}"
+  virtual_network_name = "${local.mgmt_network_name}"
+  resource_group_name  = "${local.mgmt_network_rg_name}"
 }
 
 resource "azurerm_storage_account" "storage_account" {

--- a/blob-storage.tf
+++ b/blob-storage.tf
@@ -31,6 +31,20 @@ data "azurerm_subnet" "jenkins_subnet" {
   resource_group_name  = "${local.mgmt_network_rg_name}"
 }
 
+data "azurerm_subnet" "aks_00_subnet_stg" {
+  provider             = "azurerm.mgmt"
+  name                 = "aks-00"
+  virtual_network_name = "${local.mgmt_network_name_stg}"
+  resource_group_name  = "${local.mgmt_network_rg_name_stg}"
+}
+
+data "azurerm_subnet" "aks_01_subnet_stg" {
+  provider             = "azurerm.mgmt"
+  name                 = "aks-01"
+  virtual_network_name = "${local.mgmt_network_name_stg}"
+  resource_group_name  = "${local.mgmt_network_rg_name_stg}"
+}
+
 resource "azurerm_storage_account" "storage_account" {
   name                = "${local.account_name}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
@@ -46,7 +60,7 @@ resource "azurerm_storage_account" "storage_account" {
   }
 
   network_rules {
-    virtual_network_subnet_ids = ["${data.azurerm_subnet.trusted_subnet.id}", "${data.azurerm_subnet.jenkins_subnet.id}"]
+    virtual_network_subnet_ids = ["${data.azurerm_subnet.trusted_subnet.id}", "${data.azurerm_subnet.jenkins_subnet.id}", "${data.azurerm_subnet.aks_00_subnet_stg.id}", "${data.azurerm_subnet.aks_01_subnet_stg.id}"]
     bypass                     = ["Logging", "Metrics", "AzureServices"]
     default_action             = "Deny"
   }


### PR DESCRIPTION
### Change description ###

after changing jenkins agent these subnets required to access staging storage for smoketest.
shared infra builds need to access aat and staging aat storage accounts..


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
