### PR TITLE
Notification service liveness alert

### DIFF
--- a/liveness-alert.tf
+++ b/liveness-alert.tf
@@ -22,3 +22,28 @@ EOF
   trigger_threshold          = 10
   resourcegroup_name         = "${azurerm_resource_group.rg.name}"
 }
+
+module "reform-scan-notification-service-liveness-alert" {
+  source            = "git@github.com:hmcts/cnp-module-metric-alert"
+  location          = "${azurerm_application_insights.appinsights.location}"
+  app_insights_name = "${azurerm_application_insights.appinsights.name}"
+
+  enabled    = "${var.env == "prod"}"
+  alert_name = "Reform_Scan_Notification_Service_liveness"
+  alert_desc = "Triggers when reform scan notification service looks like being down within a 30 minutes window timeframe."
+
+  app_insights_query = <<EOF
+requests
+| where name == "GET /health" and resultCode != "200"
+| where cloud_RoleName == "Reform Scan Notification Service"
+EOF
+
+  frequency_in_minutes       = 15
+  time_window_in_minutes     = 16
+  severity_level             = "2"
+  action_group_name          = "${module.alert-action-group.action_group_name}"
+  custom_email_subject       = "Reform Scan Notification Service liveness"
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold          = 10
+  resourcegroup_name         = "${azurerm_resource_group.rg.name}"
+}

--- a/liveness-alert.tf
+++ b/liveness-alert.tf
@@ -9,7 +9,7 @@ module "blob-router-service-liveness-alert" {
 
   app_insights_query = <<EOF
 requests
-| where name == "GET /health" and resultCode != "200"
+| where url contains "/health" and success != "True"
 | where cloud_RoleName == "Blob Router Service"
 EOF
 
@@ -34,7 +34,7 @@ module "reform-scan-notification-service-liveness-alert" {
 
   app_insights_query = <<EOF
 requests
-| where name == "GET /health" and resultCode != "200"
+| where url contains "/health" and success != "True"
 | where cloud_RoleName == "Reform Scan Notification Service"
 EOF
 

--- a/liveness-alert.tf
+++ b/liveness-alert.tf
@@ -9,7 +9,7 @@ module "blob-router-service-liveness-alert" {
 
   app_insights_query = <<EOF
 requests
-| where url contains "/health" and success != "True"
+| where url endswith "/health/liveness" and success != "True"
 | where cloud_RoleName == "Blob Router Service"
 EOF
 
@@ -34,7 +34,7 @@ module "reform-scan-notification-service-liveness-alert" {
 
   app_insights_query = <<EOF
 requests
-| where url contains "/health" and success != "True"
+| where url endswith "/health/liveness" and success != "True"
 | where cloud_RoleName == "Reform Scan Notification Service"
 EOF
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/BPS-1347


### Change description ###
Added missing alert for notification service liveness. Also updated request in the existing alert after Don's comment.

Requests were tested in Azure portal prod with _success == "True"_

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
