### PR TITLE
DTSPO-6371 - add private endpoint provider to service bus module

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -8,6 +8,6 @@ provider "azurerm" {
 provider "azurerm" {
   features {}
   skip_provider_registration = true
-  alias                      = "private-endpoint"
+  alias                      = "private_endpoint"
   subscription_id            = var.aks_subscription_id
 }

--- a/provider.tf
+++ b/provider.tf
@@ -4,3 +4,10 @@ provider "azurerm" {
   subscription_id = "ed302caf-ec27-4c64-a05e-85731c3ce90e"
   features {}
 }
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}

--- a/queue-premium.tf
+++ b/queue-premium.tf
@@ -1,6 +1,6 @@
 module "queue-namespace-premium" {
   providers = {
-    azurerm.private-endpoint = azurerm.private-endpoint
+    azurerm.private_endpoint = azurerm.private_endpoint
   }
   
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"

--- a/queue-premium.tf
+++ b/queue-premium.tf
@@ -1,4 +1,8 @@
 module "queue-namespace-premium" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
+  
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${local.product}-servicebus-${var.env}-premium"
   location            = var.location

--- a/queue.tf
+++ b/queue.tf
@@ -1,6 +1,6 @@
 module "queue-namespace" {
   providers = {
-    azurerm.private-endpoint = azurerm.private-endpoint
+    azurerm.private_endpoint = azurerm.private_endpoint
   }
   
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"

--- a/queue.tf
+++ b/queue.tf
@@ -1,4 +1,8 @@
 module "queue-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
+  
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = "${local.product}-servicebus-${var.env}"
   location            = var.location

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,5 @@ variable "external_hostname" {
 variable "enable_staging_account" {
   default = 0
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6371


### Change description ###
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created. 

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module. 

More information on that can be found here: https://github.com/hmcts/terraform-module-servicebus-namespace#usage


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
